### PR TITLE
Update index.html

### DIFF
--- a/icij-paradise-papers/index.html
+++ b/icij-paradise-papers/index.html
@@ -99,7 +99,7 @@
         <pre mode="cypher"  class="highlight pre-scrollable code runnable standalone-example ng-binding"><code class="cypher language-cypher">MATCH (a:Officer),(b:Officer)
 WHERE a.name CONTAINS 'Ross, Jr' 
   AND b.name CONTAINS 'Grant'
-MATCH p=allShortestPaths((a)-[:OFFICER_OF|:INTERMEDIARY_OF|:REGISTERED_ADDRESS*..10]-(b))
+MATCH p=allShortestPaths((a)-[:OFFICER_OF|INTERMEDIARY_OF|REGISTERED_ADDRESS*..10]-(b))
 RETURN p
 LIMIT 50</code></pre>
 


### PR DESCRIPTION
Fix for:

Neo.ClientError.Statement.SyntaxError
The semantics of using colon in the separation of alternative relationship types in conjunction with
the use of variable binding, inlined property predicates, or variable length is no longer supported.
Please separate the relationships types using `:A|B|C` instead (line 4, column 29 (offset: 122))
"MATCH p=allShortestPaths((a)-[:OFFICER_OF|:INTERMEDIARY_OF|:REGISTERED_ADDRESS*..10]-(b))"